### PR TITLE
Método POST para o recurso de Despesa (cadastro) 

### DIFF
--- a/src/main/kotlin/br/com/dutech/backbudget/controller/ExpenseController.kt
+++ b/src/main/kotlin/br/com/dutech/backbudget/controller/ExpenseController.kt
@@ -1,11 +1,15 @@
 package br.com.dutech.backbudget.controller
 
+import br.com.dutech.backbudget.dto.NewExpenseForm
 import br.com.dutech.backbudget.model.Expense
 import br.com.dutech.backbudget.service.ExpenseService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/expenses")
@@ -19,6 +23,11 @@ class ExpenseController(val service: ExpenseService) {
     @GetMapping("/{id}")
     fun getExpenseDetail(@PathVariable id: Long): Expense {
         return service.getExpenseDetail(id)
+    }
+
+    @PostMapping
+    fun registerExpense(@RequestBody @Valid form: NewExpenseForm){
+        service.registerExpense(form)
     }
 
 

--- a/src/main/kotlin/br/com/dutech/backbudget/dto/NewExpenseForm.kt
+++ b/src/main/kotlin/br/com/dutech/backbudget/dto/NewExpenseForm.kt
@@ -1,0 +1,13 @@
+package br.com.dutech.backbudget.dto
+
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.NotEmpty
+
+data class NewExpenseForm(
+    @field:NotEmpty
+    val description: String,
+    @field:DecimalMin("1.00")
+    val value: Double,
+    @field:NotEmpty
+    val date: String
+)

--- a/src/main/kotlin/br/com/dutech/backbudget/mapper/ExpenseFormMapper.kt
+++ b/src/main/kotlin/br/com/dutech/backbudget/mapper/ExpenseFormMapper.kt
@@ -1,0 +1,18 @@
+package br.com.dutech.backbudget.mapper
+
+import br.com.dutech.backbudget.dto.NewExpenseForm
+import br.com.dutech.backbudget.model.Expense
+import org.springframework.stereotype.Component
+
+@Component
+class ExpenseFormMapper : Mapper<NewExpenseForm, Expense> {
+
+    override fun map(t: NewExpenseForm): Expense {
+        return Expense(
+            description = t.description,
+            value = t.value,
+            date = t.date
+        )
+    }
+
+}

--- a/src/main/kotlin/br/com/dutech/backbudget/mapper/Mapper.kt
+++ b/src/main/kotlin/br/com/dutech/backbudget/mapper/Mapper.kt
@@ -1,0 +1,5 @@
+package br.com.dutech.backbudget.mapper
+
+interface Mapper<T, U> {
+    fun map(t: T): U
+}

--- a/src/main/kotlin/br/com/dutech/backbudget/model/Expense.kt
+++ b/src/main/kotlin/br/com/dutech/backbudget/model/Expense.kt
@@ -1,10 +1,8 @@
 package br.com.dutech.backbudget.model
 
-import java.time.LocalDateTime
-
 data class Expense(
-    val id: Long? = null,
+    var id: Long? = null,
     val description: String,
     val value: Double,
-    val date: LocalDateTime
+    val date: String
 )

--- a/src/main/kotlin/br/com/dutech/backbudget/service/ExpenseService.kt
+++ b/src/main/kotlin/br/com/dutech/backbudget/service/ExpenseService.kt
@@ -1,29 +1,15 @@
 package br.com.dutech.backbudget.service
 
+import br.com.dutech.backbudget.dto.NewExpenseForm
+import br.com.dutech.backbudget.mapper.ExpenseFormMapper
 import br.com.dutech.backbudget.model.Expense
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
-import java.util.*
 
 @Service
-class ExpenseService(private var expenses: List<Expense>) {
-
-    init {
-        val expense1 = Expense(
-            id = 1,
-            description = "Supermarket",
-            value = 300.00,
-            date = LocalDateTime.now()
-        )
-        val expense2 = Expense(
-            id = 2,
-            description = "Restaurant",
-            value = 100.00,
-            date = LocalDateTime.now()
-        )
-
-        expenses = Arrays.asList(expense1, expense2)
-    }
+class ExpenseService(
+    private var expenses: List<Expense>,
+    private val expenseFormMapper: ExpenseFormMapper
+) {
 
     fun getExpenseList(): List<Expense> {
         return expenses
@@ -33,6 +19,12 @@ class ExpenseService(private var expenses: List<Expense>) {
         return expenses.stream().filter { e ->
             e.id == id
         }.findFirst().get()
+    }
+
+    fun registerExpense(form: NewExpenseForm) {
+        val expense = expenseFormMapper.map(form)
+        expense.id = expenses.size.toLong() + 1
+        expenses = expenses.plus(expense)
     }
 
 }


### PR DESCRIPTION
Desenvolvi o cadastro de despesa para a aplicação. 
A partir do controller, criei um método `registerExpense` recebendo um form como parâmetro (NewExpenseForm).
Em seguida implementei o tratamento de form para model para poder cadastrar a despesa na Lista de Despesas, na `ExpenseService`.
Nessa mesma função, utilizo a função `map` da Classe `ExpenseFormMapper` para realizar a transformação de form para model.

* Vale ressaltar o uso de Bean Validation na Classe `NewExpenseForm`. O uso dessas anotações garante a integridade do Request, como campos preenchidos e valor da despesa cadastrada maior que `1.00`. Além das anotações no form, foi preciso inserir `@Valid` na função `registerExpense` na Classe ExpenseController.

* A princípio vou deixar o campo `date` como String, futuramente pretendo refatorar esse campo para o tipo correto de Data.